### PR TITLE
Add missing error handler for request.

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,14 @@ MobProxy.prototype = {
         };
 
         var request = http.request(options, respCallback);
-        if(data) { request.write(data); }
+
+        request.on('error', function(err) {
+          if (callback !== undefined) {
+            callback(err, null);
+          }
+        });
+
+      if(data) { request.write(data); }
         request.end();
     }
 


### PR DESCRIPTION
This fixes an annoying "Uncaught Error: socket hang up" that would crash the process if server had issues.